### PR TITLE
marquee mode

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -102,6 +102,16 @@ For syntax highlighting and intellisense, use the [vscode-styled-components](htt
 import { scss as css } from '@acab/ecsstatic';
 ```
 
+## Atomic classes
+
+There is an experimental flag `marqueeMode`. When enabled, the prod build output will contain atomic classes, where one class maps to one declaration. This can potentially result in a smaller CSS file, at the cost of bloating the markup with lots of classes. This tradeoff can be worth it for large sites where the size of the CSS would be a concern.
+
+```js
+export default defineConfig({
+  plugins: [ecsstatic({ marqueeMode: true })],
+});
+```
+
 ## Prior art
 
 Huge shoutout to the previous libraries that came before this; ecsstatic would not have been possible without them paving the way.

--- a/package/vite.ts
+++ b/package/vite.ts
@@ -38,11 +38,11 @@ type Options = {
 	 */
 	classNamePrefix?: string;
 	/**
-	 * When enabled, the final output of the prod bundle will contain atomic classes, which can result in a
-	 * smaller CSS file, at the cost of bloating the markup with lots of classes. This tradeoff can be worth it
-	 * for large sites where the size of the CSS would be a concern.
+	 * When enabled, the final output of the prod bundle will contain atomic classes, where one class maps to one declaration.
+	 * This can result in a smaller CSS file, at the cost of bloating the markup with lots of classes. This tradeoff can be worth
+	 * it for large sites where the size of the CSS would be a concern.
 	 *
-	 * By default, these classes will be prefixed with 🤡. A different prefix can be provided by passing an object.
+	 * By default, these classes will be prefixed with 🤡. A different prefix can be specified by passing an object.
 	 *
 	 * @experimental
 	 *


### PR DESCRIPTION
this PR adds a `marqueeMode` flag, as a fun experiment.

we've all seen the marquee before.

<img src="https://user-images.githubusercontent.com/9084735/218216099-a353d868-ed54-4912-8bc9-82540eadfc64.gif" width="600">

<img src="https://user-images.githubusercontent.com/9084735/218214960-983c7ef7-9559-4806-880d-64ec0812e03f.gif" width="600">

in prod mode, the resulting markup will be bloated with ✨ _Securely Scoped Styles_ ✨. dev mode is unaffected for better debugging experience.

potential benefits are smaller CSS size, at the cost of larger HTML size.

currently pending issues:
- [x] ~~drops some rules, like `@font-face`~~
- [x] ~~not tested in sass~~
- [x] ~~prefix doesn't currently work~~