### PR TITLE
use both postcss-nesting and postcss-nested

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -42,7 +42,8 @@
 		"esbuild-plugin-noexternal": "^0.1.5",
 		"magic-string": "^0.27.0",
 		"postcss": "^8.4.19",
-		"postcss-nesting": "^11.1.0",
+		"postcss-nested": "^6.0.0",
+		"postcss-nesting": "^11.2.0",
 		"postcss-scss": "^4.0.6"
 	},
 	"devDependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -42,7 +42,7 @@
 		"esbuild-plugin-noexternal": "^0.1.5",
 		"magic-string": "^0.27.0",
 		"postcss": "^8.4.19",
-		"postcss-nested": "^6.0.0",
+		"postcss-nested": "^6.0.1",
 		"postcss-nesting": "^11.2.0",
 		"postcss-scss": "^4.0.6"
 	},

--- a/package/vite.ts
+++ b/package/vite.ts
@@ -206,11 +206,7 @@ function processCss(
 	const unprocessedCss = `${importsAndUses}\n.${className}{${codeWithoutImportsAndUses}}`;
 
 	const plugins = !isScss
-		? [
-				postcssNesting(),
-				postcssNested({ bubble: ['@container', '@scope'] }),
-				autoprefixer(autoprefixerOptions),
-		  ]
+		? [postcssNesting(), postcssNested(), autoprefixer(autoprefixerOptions)]
 		: [autoprefixer(autoprefixerOptions)];
 	const options = isScss ? { parser: postcssScss } : {};
 	const { css } = postcss(plugins).process(unprocessedCss, options);

--- a/package/vite.ts
+++ b/package/vite.ts
@@ -4,6 +4,7 @@ import MagicString from 'magic-string';
 import path from 'path';
 import postcss from 'postcss';
 import postcssNesting from 'postcss-nesting';
+import postcssNested from 'postcss-nested';
 import postcssScss from 'postcss-scss';
 import { ancestor as walk } from 'acorn-walk';
 import autoprefixer from 'autoprefixer';
@@ -205,7 +206,11 @@ function processCss(
 	const unprocessedCss = `${importsAndUses}\n.${className}{${codeWithoutImportsAndUses}}`;
 
 	const plugins = !isScss
-		? [postcssNesting(), autoprefixer(autoprefixerOptions)]
+		? [
+				postcssNesting(),
+				postcssNested({ bubble: ['@container', '@scope'] }),
+				autoprefixer(autoprefixerOptions),
+		  ]
 		: [autoprefixer(autoprefixerOptions)];
 	const options = isScss ? { parser: postcssScss } : {};
 	const { css } = postcss(plugins).process(unprocessedCss, options);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
       turbo: latest
     devDependencies:
       prettier: 2.7.1
-      turbo: 1.7.4
+      turbo: 1.8.1
 
   demos/astro-react:
     specifiers:
@@ -139,7 +139,8 @@ importers:
       esbuild-plugin-noexternal: ^0.1.5
       magic-string: ^0.27.0
       postcss: ^8.4.19
-      postcss-nesting: ^11.1.0
+      postcss-nested: ^6.0.0
+      postcss-nesting: ^11.2.0
       postcss-scss: ^4.0.6
       tsup: ^6.5.0
       vite: ^4.0.0
@@ -150,7 +151,8 @@ importers:
       esbuild-plugin-noexternal: 0.1.5
       magic-string: 0.27.0
       postcss: 8.4.21
-      postcss-nesting: 11.1.0_postcss@8.4.21
+      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-nesting: 11.2.1_postcss@8.4.21
       postcss-scss: 4.0.6_postcss@8.4.21
     devDependencies:
       '@types/estree': 1.0.0
@@ -3566,8 +3568,18 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-nesting/11.1.0_postcss@8.4.21:
-    resolution: {integrity: sha512-TVBCeKlUmMyX3sNeSg10yATb2XmAoosp0E1zdlpjrD+L2FrQPmrRTxlRFQh/R0Y4WlQ0butfDwRhzlYuj7y/TA==}
+  /postcss-nested/6.0.0_postcss@8.4.21:
+    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss: 8.4.21
+      postcss-selector-parser: 6.0.10
+    dev: false
+
+  /postcss-nesting/11.2.1_postcss@8.4.21:
+    resolution: {integrity: sha512-E6Jq74Jo/PbRAtZioON54NPhUNJYxVWhwxbweYl1vAoBYuGlDIts5yhtKiZFLvkvwT73e/9nFrW3oMqAtgG+GQ==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.4
@@ -4246,65 +4258,65 @@ packages:
       - ts-node
     dev: true
 
-  /turbo-darwin-64/1.7.4:
-    resolution: {integrity: sha512-ZyYrQlUl8K/mYN1e6R7bEhPPYjMakz0DYMaexkyD7TAijQtWmTSd4a+I7VknOYNEssnUZ/v41GU3gPV1JAzxxQ==}
+  /turbo-darwin-64/1.8.1:
+    resolution: {integrity: sha512-H7pxGF/vsYG7kbY+vB8h+3r8VXn2L6hhYQi0XWA+EjZ1e2zu7+TzEMRWFYmvJPx8TRo5cV5txtg0I22/Y7bxUA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.7.4:
-    resolution: {integrity: sha512-CKIXg9uqp1a+Yeq/c4U0alPOqvwLUq5SBZf1PGYhGqJsfG0fRBtJfkUjHuBsuJIOGXg8rCmcGSWGIsIF6fqYuw==}
+  /turbo-darwin-arm64/1.8.1:
+    resolution: {integrity: sha512-zMcvplVGluR6v4oJXW7S1/R9QFsHdDkXMhPq8PIdvT3HwTb69ms0MNv7aKiQ0ZFy5D/eKCTyBRUFZvjorZmBqA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.7.4:
-    resolution: {integrity: sha512-RIUl4RUFFyzD2T024vL7509Ygwcw+SEa8NOwPfaN6TtJHK7RZV/SBP3fLNVOptG9WRLnOWX3OvsLMbiOqDLLyA==}
+  /turbo-linux-64/1.8.1:
+    resolution: {integrity: sha512-eJNx8iWDn5Lt8d0221RFd6lBjViLiPCVWNFF5JtqOohgRYplvepY3y/THa1GivMxY4px6zjTiy2oPE/VscVP4w==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.7.4:
-    resolution: {integrity: sha512-Bg65F0AjYYYxqE6RPf2H5TIGuA/EyWMeGOATHVSZOWAbYcnG3Ly03GZii8AHnUi7ntWBdjwvXf/QbOS1ayNB6A==}
+  /turbo-linux-arm64/1.8.1:
+    resolution: {integrity: sha512-hFZkm8tq9kLE8tdbOzD6EbNzftdzMR4JEuuoKC6AbTzx1ZsWRvXJ/BGTeSH9/dYYm/wfuIEUiOP7HeXWiZRx7g==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.7.4:
-    resolution: {integrity: sha512-rTaV50XZ2BRxRHOHqt1UsWfeDmYLbn8UKE6g2D2ED+uW+kmnTvR9s01nmlGWd2sAuWcRYQyQ2V+O09VfKPKcQw==}
+  /turbo-windows-64/1.8.1:
+    resolution: {integrity: sha512-o3oDg0lTYZl5KZD3Mi753On2vQT51unIiungoUmHDCeDH5JXfWPFu+6p+GAoIyRwQkZPvaEzMLuUtRgklKcBJw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.7.4:
-    resolution: {integrity: sha512-h8sxdKPvHTnWUPtwnYszFMmSO0P/iUUwmYY9n7iYThA71zSao28UeZ0H0Gw75cY3MPjvkjn2C4EBAUGPjuZJLw==}
+  /turbo-windows-arm64/1.8.1:
+    resolution: {integrity: sha512-NDYr2Mra21KOdl18BhMRoH2jQmlu+oqkpqRd+cGB8+c5P0B6LDVCM83cfcXQ+PNqX9S3Y1eZDRENZJx9I03sSw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.7.4:
-    resolution: {integrity: sha512-8RLedDoUL0kkVKWEZ/RMM70BvKLyDFen06QuKKhYC2XNOfNKqFDqzIdcY/vGick869bNIWalChoy4O07k0HLsA==}
+  /turbo/1.8.1:
+    resolution: {integrity: sha512-g8RltmG5zd0nYbKpkBQwnTSXTWUiup9+yileQ1TETNzpjxI3TL5k7kt2WkgUHEqR947IPUV+ckIduZHVITJmIQ==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.7.4
-      turbo-darwin-arm64: 1.7.4
-      turbo-linux-64: 1.7.4
-      turbo-linux-arm64: 1.7.4
-      turbo-windows-64: 1.7.4
-      turbo-windows-arm64: 1.7.4
+      turbo-darwin-64: 1.8.1
+      turbo-darwin-arm64: 1.8.1
+      turbo-linux-64: 1.8.1
+      turbo-linux-arm64: 1.8.1
+      turbo-windows-64: 1.8.1
+      turbo-windows-arm64: 1.8.1
     dev: true
 
   /type-fest/0.13.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
       esbuild-plugin-noexternal: ^0.1.5
       magic-string: ^0.27.0
       postcss: ^8.4.19
-      postcss-nested: ^6.0.0
+      postcss-nested: ^6.0.1
       postcss-nesting: ^11.2.0
       postcss-scss: ^4.0.6
       tsup: ^6.5.0
@@ -151,7 +151,7 @@ importers:
       esbuild-plugin-noexternal: 0.1.5
       magic-string: 0.27.0
       postcss: 8.4.21
-      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-nested: 6.0.1_postcss@8.4.21
       postcss-nesting: 11.2.1_postcss@8.4.21
       postcss-scss: 4.0.6_postcss@8.4.21
     devDependencies:
@@ -3568,14 +3568,14 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-nested/6.0.0_postcss@8.4.21:
-    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+  /postcss-nested/6.0.1_postcss@8.4.21:
+    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
       postcss: 8.4.21
-      postcss-selector-parser: 6.0.10
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-nesting/11.2.1_postcss@8.4.21:
@@ -3600,6 +3600,14 @@ packages:
 
   /postcss-selector-parser/6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /postcss-selector-parser/6.0.11:
+    resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0


### PR DESCRIPTION
In 0.5.0 (through [`ba9a35`](https://github.com/mayank99/ecsstatic/commit/ba9a35ad29708106a8ce7ee86eb0df3b7cc81b56)), `postcss-nested` was replaced with `postcss-nesting` which more closely follows the spec. 

But the spec disallows certain kinds of nesting. For example, the following is invalid:
```css
.foo {
  span {
    color: hotpink;
  }
}
```

It actually worked when 0.5.0 was first released, but `postcss-nesting` recently had a [breaking change](https://github.com/csstools/postcss-plugins/pull/861/files) (in a patch release!) which broke it. Or you could call it a bug fix, since it's disallowed in the spec. Either way, not a very nice outcome.

To combat this, I am reintroducing `postcss-nested`, but not replacing `postcss-nesting` entirely. The idea is that anything not picked up by `postcss-nesting` will instead be processed through `postcss-nested`. This should make it more resilient, and also make the behavior consistent with `scss`. For example, `@keyframes` and `@font-face` rules will unwrap now.

```css
.foo {
  /* works in postcss-nested, not in postcss-nesting */
  @keyframes bar {
    to { opacity: 1 };
  }
}
```

There might be cases where such behavior is not desirable, in which case I might expose an option that lets the user control it. But for now, I think this is the best option.