### PR TITLE
support vite 6

### DIFF
--- a/package/vite.ts
+++ b/package/vite.ts
@@ -204,7 +204,7 @@ function processCss(
 		classNamePrefix?: string;
 		isDev: boolean;
 		marqueeMode: Options['marqueeMode'];
-	},
+	}
 ) {
 	const {
 		isScss = false,
@@ -318,7 +318,7 @@ async function evalWithEsbuild(expression: string, allVarDeclarations = '') {
 	} catch (err) {
 		if (err instanceof Error) {
 			const e = new Error(
-				err.message.substring(err.message.lastIndexOf(args.at(-1)!) + args.at(-1)!.length),
+				err.message.substring(err.message.lastIndexOf(args.at(-1)!) + args.at(-1)!.length)
 			);
 			e.stack = e.stack
 				?.split('\n')
@@ -335,7 +335,7 @@ async function evalWithEsbuild(expression: string, allVarDeclarations = '') {
 /** uses esbuild.build to resolve all imports and return the "bundled" code */
 async function inlineVarsUsingEsbuild(
 	fileId: string,
-	{ noExternal = [] as string[], classNamePrefix = '🎈' },
+	{ noExternal = [] as string[], classNamePrefix = '🎈' }
 ) {
 	const processedCode = (
 		await esbuild.build({
@@ -533,8 +533,8 @@ function generateMarquee(code: string, { originalClass = '', isScss = false, pre
 							root!.append(rule);
 						}
 					},
-				}) as Postcss.AcceptedPlugin,
-			{ postcss: true },
+				} as Postcss.AcceptedPlugin),
+			{ postcss: true }
 		)(),
 	]).process(code, isScss ? { parser: postcssScss } : {});
 


### PR DESCRIPTION
In Vite 6, CSS in SSR no longer returns a default export of the processed CSS itself. Consumers need to do `foobar.css?inline` to retrieve that instead.  This aligns with the same behaviour in the client-side but Vite had forgot to make the change for SSR, but did so in Vite 6: https://github.com/vitejs/vite/pull/17922

This PR adds support for the virtual CSS to accept `?inline` (and any queries in general) to be resolved and loaded. I handled all kinds of queries instead of only `?inline` as other queries like `?url` could also be useful, or if some plugins want to attach some metadata to the id. But I'm happy to make it strict to handle `?inline` only if you prefer so.

Ref https://github.com/withastro/astro/issues/12616